### PR TITLE
Question about reorder_vertices.jl

### DIFF
--- a/src/reorder_vertices.jl
+++ b/src/reorder_vertices.jl
@@ -20,8 +20,10 @@ function reorder(t,s, strat::CommonVertex)
         e == 2 && break
     end
 
-    append!(I, setdiff([1,2,3], I))
-    append!(J, setdiff([1,2,3], J))
+    #append!(I, setdiff([1,2,3], I))
+    #append!(J, setdiff([1,2,3], J))
+    append!(setdiff([1,2,3], I), I)
+    append!(setdiff([1,2,3], J), J)
 
     # # inverse permutations
     # K = indexin([1,2,3], I)


### PR DESCRIPTION
Hello :) 

Thank you very much for the code. I have a question about the vertex ordering for the CommonVertex case.  The orders Pt = [P, A1, A2] and Ps = [P, B1, B2] is proposed in the book of Sauter and Schwab. Since this package uses the triangle representation x = x[3] + u*(x[1]-x[3]) + v*(x[2]-x[3]), is it possible that Pt = [A1, A2, P] and Ps = [B1, B2, P] might be the choice for the orders?  In this case, the parameters u=0 and v=0 would point to the same node in both triangles.  As I said, I am not completely sure, but I copied my proposal into the code. 

Best regards!